### PR TITLE
added CP437 import to output_filter

### DIFF
--- a/x84/bbs/door.py
+++ b/x84/bbs/door.py
@@ -375,6 +375,8 @@ class Door(object):
         """ Given door output in bytes, if 'cp437' is specified in class
         constructor, convert to utf8 glyphs using cp437 encoding; otherwise
         decode output as utf8. """
+        from x84.bbs.cp437 import CP437
+        
         if self.cp437:
             return u''.join((CP437[ord(ch)] for ch in data))
 


### PR DESCRIPTION
I got Usurper working, but I had to fix the output_filter function before it would stop throwing unicode errors.
