### PR TITLE
Added sesame door system

### DIFF
--- a/x84/bbs/door.py
+++ b/x84/bbs/door.py
@@ -265,7 +265,8 @@ class Door(object):
     master_fd = None
 
     def __init__(self, cmd='/bin/uname', args=(), env_lang='en_US.UTF-8',
-                 env_term=None, env_path=None, env_home=None, cp437=False):
+                 env_term=None, env_path=None, env_home=None, cp437=False,
+                 env={}):
         # pylint: disable=R0913
         #        Too many arguments (7/5)
         """
@@ -299,7 +300,7 @@ class Door(object):
             self.env_home = os.getenv('HOME')
         else:
             self.env_home = env_home
-        self.env = None # add additional env variables ...
+        self.env = env # add additional env variables ...
         self.cp437 = cp437
         self._utf8_decoder = codecs.getincrementaldecoder('utf8')()
 
@@ -310,7 +311,7 @@ class Door(object):
         IPC data to and from the slave pty until child process exits.
         """
         logger = logging.getLogger()
-        env = dict() if self.env is None else self.env
+        env = self.env.copy()
         env.update({'LANG': self.env_lang,
                'TERM': self.env_term,
                'PATH': self.env_path,

--- a/x84/bbs/ini.py
+++ b/x84/bbs/ini.py
@@ -199,6 +199,17 @@ def init_bbs_ini():
     cfg_bbs.set('dosemu', 'lord_args',
             '-quiet -I \'$_com1 = "virtual"\' \'X:\\LORD\\START.BAT %%#\'')
 
+    cfg_bbs.add_section('sesame')
+    cfg_bbs.set('sesame', 'CavesOfPhear', '/usr/bin/phear')
+    cfg_bbs.set('sesame', 'CavesOfPhear_key', '!')
+    cfg_bbs.set('sesame', 'FrozenDepths', '/usr/bin/frozendepths')
+    cfg_bbs.set('sesame', 'FrozenDepths_key', '@')
+    cfg_bbs.set('sesame', 'DopeWars',
+        '/usr/bin/dopewars -a -P {session[handle]} --single-player -u none')
+    cfg_bbs.set('sesame', 'DopeWars_key', '$')
+    cfg_bbs.set('sesame', 'MyMan', '/usr/bin/myman')
+    cfg_bbs.set('sesame', 'MyMan_key', '&')
+
     cfg_bbs.add_section('ttyplay')
     cfg_bbs.set('ttyplay', 'exe', '/usr/bin/ttyplay')
     return cfg_bbs

--- a/x84/bbs/session.py
+++ b/x84/bbs/session.py
@@ -93,6 +93,25 @@ class Session(object):
         self._ttyrec_usec = -1
         self._ttyrec_len_text = 0
 
+    def to_dict(self):
+        """
+        Returns a dictionary containing information about this session object.
+        """
+        return {
+            attr: getattr(self, attr)
+            for attr in (
+                'connect_time',
+                'last_input_time',
+                'idle',
+                'activity',
+                'handle',
+                'user',
+                'encoding',
+                'pid',
+                'node',
+            )
+        }
+
     @property
     def duration(self):
         """

--- a/x84/default/sesame.py
+++ b/x84/default/sesame.py
@@ -1,0 +1,86 @@
+import ConfigParser
+import shlex
+import os
+
+def main(name):
+    from x84.bbs import getsession, getterminal, echo, ini
+    from x84.bbs import Door
+
+    session, term = getsession(), getterminal()
+    session_info = session.to_dict()
+    system_info = dict(ini.CFG.items('system'))
+
+    store_cols, store_rows = None, None
+    try:
+        want_cols = ini.CFG.getint('sesame', '{}_cols'.format(name))
+        want_rows = ini.CFG.getint('sesame', '{}_rows'.format(name))
+        if want_cols != term.width or want_rows != term.height:
+            echo(u'\x1b[8;%d;%dt' % (want_rows, want_cols,))
+        disp = 1
+        while not (term.width == want_cols
+                and term.height == want_cols):
+            if disp:
+                echo(term.bold_blue('\r\n^\r\n'))
+                echo(term.bold_blue('\r\n'.join([u'|'] * (want_rows - 3))))
+                echo(u'\r\n')
+                echo(term.bold_blue(u'|' + (u'=' * 78) + u'|\r\n'))
+                echo(u'for best "screen output", please '
+                    'resize window to %s x %s (or press return).' % (
+                        want_cols, want_rows,))
+                disp = 0
+            ret = term.inkey(2)
+            if ret in (term.KEY_ENTER, u'\r', u'\n'):
+                break
+
+        if term.width != want_cols or term.height != want_rows:
+            echo(u'Your dimensions: %s by %s; emulating %s by %s !' % (
+                term.width, term.height, want_cols, want_rows,))
+            # hand-hack, its ok ... really
+            store_cols, store_rows = term.width, term.height
+            term.columns, term.rows= want_cols, want_rows
+            term.inkey(1)
+
+    except ConfigParser.NoOptionError:
+        pass  # no size requirements, assume we're good...
+
+    # Parse command path and arguments
+    command = ini.CFG.get('sesame', name)
+    if ' ' in command:
+        command, args = command.split(' ', 1)
+        args = args.format(
+            session=session_info,
+            **system_info
+        )
+        args = shlex.split(args)
+    else:
+        args = []
+
+    assert command != 'no'
+    assert os.path.exists(command)
+
+    # Now setup the environment (if any exists)
+    env = dict()
+    env_prefix = '_'.join([name, 'env', ''])
+    for option in ini.CFG.options('sesame'):
+        if option.startswith(env_prefix):
+            key = option.replace(env_prefix, '')
+            env[key] = ini.CFG.get('sesame', option).format(
+                session=session_info,
+                **system_info
+            )
+
+    session.activity = u'Playing {}'.format(name)
+    door = Door(
+        command,
+        args=args,
+        env_home=env.get('HOME'),
+        env_path=env.get('PATH'),
+        env=env
+    )
+    door.run()
+    echo(term.clear)
+    if not (store_cols is None and store_rows is None):
+        echo(u'Restoring dimensions to %s by %s !' % (store_cols, store_rows))
+        term.rows, term.columns = store_rows, store_cols
+    echo(u'\r\n')
+    term.inkey(0.5)


### PR DESCRIPTION
This is a basic door system that allows one to add multiple doors to the main
menu by simply configuring them in the default.ini file. One can specify a door
as follows:

```
[sesame]
door = /path/to/door
door_key = @
```

If you wish to override environment variables for the door, you can use Python
format string syntax. All of the [system] level configuration variables are
available and also session information via the session dictionary:

```
[sesame]
door = /path/to/door
door_key = @
door_env_USER = {session[handle]}
door_env_ROOT = {datapath}
...
```
