### PR TITLE
fail2ban-like ip blacklisting mechanism

### DIFF
--- a/x84/engine.py
+++ b/x84/engine.py
@@ -177,25 +177,25 @@ def accept(log, server):
 
         try:
             max_attempted_logins = CFG.getint(
-                'fail2ban', 'max_attempted_logins') or 3
+                'fail2ban', 'max_attempted_logins')
         except ConfigParser.NoOptionError:
             pass
 
         try:
             max_attempted_logins_window = CFG.getint(
-                'fail2ban', 'max_attempted_logins_window') or 30
+                'fail2ban', 'max_attempted_logins_window')
         except ConfigParser.NoOptionError:
             pass
 
         try:
             initial_ban_length = CFG.getint(
-                'fail2ban', 'initial_ban_length') or 360
+                'fail2ban', 'initial_ban_length')
         except ConfigParser.NoOptionError:
             pass
 
         try:
             ban_increment_length = CFG.getint(
-                'fail2ban', 'ban_increment_length') or 360
+                'fail2ban', 'ban_increment_length')
         except ConfigParser.NoOptionError:
             pass
 


### PR DESCRIPTION
This adds a fail2ban-like IP blacklisting mechanism to x/84. If an IP makes a connection more than w times in x seconds, their IP will be blacklisted for y seconds. Any further attempts during the blacklisting window will increase their ban time by z seconds.

All options have defaults; just adding `[fail2ban]` to `default.ini` is enough to enable the mechanism. If you want to override them, however, here is an example:

```
[fail2ban]
ip_blacklist = 1.2.3.4 5.6.7.8    ; list of IPs to permanently ban
max_attempted_logins = 3          ; attempts per window before ban
max_attempted_logins_window = 30  ; seconds for window
initial_ban_length = 360          ; seconds to ban someone at first
ban_increment_length = 360        ; seconds to add for repeated attempts during ban
```
