### PR TITLE
sftp server, file browser

### DIFF
--- a/x84/default/common.py
+++ b/x84/default/common.py
@@ -169,3 +169,24 @@ def show_description(description, color='white', width=80):
         echo(txt.rstrip())
         echo(u'\r\n')
     return line_no
+
+
+def filesize(filename):
+    """ display a file's size in human-readable format """
+
+    from os import stat
+    stat = stat(filename)
+    filesize = None
+    # file is > 400 megabytes; display in gigabytes
+    if stat.st_size > 1024000 * 400:
+        filesize = '%.2fG' % (stat.st_size / 1024000000)
+    # file is > 400 kilobytes; display in megabytes
+    if stat.st_size > 1024 * 400:
+        filesize = '%.2fM' % (stat.st_size / 1024000)
+    # file is at least 1 kilobyte; display in kilobytes
+    elif stat.st_size >= 1024:
+        filesize = '%.2fK' % (stat.st_size / 1024)
+    # display in bytes
+    else:
+        filesize = '%dB' % stat.st_size
+    return filesize

--- a/x84/default/fbrowse.py
+++ b/x84/default/fbrowse.py
@@ -1,0 +1,394 @@
+""" File browsing/tagging for x/84 bbs https://github.com/jquast/x84 """
+
+from __future__ import division
+import zipfile
+import os
+
+
+### archive extraction functions ###
+
+def diz_from_zip(filename, method=zipfile.ZIP_STORED):
+    """
+    unzip `filename` using particular zipfile `method`
+    supports zip, bz2, bzip2; decodes FILE_ID.DIZ as cp437_art
+    """
+
+    try:
+        myzip = zipfile.ZipFile(filename, compression=method, allowZip64=True)
+        for cname in (cname for cname in myzip.namelist()
+                if cname.lower() == 'file_id.diz'):
+            return myzip.read(cname).decode('cp437_art')
+        else:
+            return u'No description'
+    except zipfile.BadZipfile:
+        return u'Bad zip file, cannot parse'
+    except zipfile.LargeZipFile:
+        # since we do allowZip64=True above, this shouldn't happen any longer
+        return u'Large zip file, cannot parse'
+    except NotImplementedError:
+        return u'Unsupported compression, cannot parse'
+
+
+def diz_from_bzip2(filename):
+    """
+    wrapper to call `diz_from_zip` using `zipfile.ZIP_BZIP2` method
+    """
+
+    return diz_from_zip(filename, method=zipfile.ZIP_BZIP2)
+
+
+### config ###
+
+# map extensions to helper functions for pulling FILE_ID.DIZ
+diz_extractors = {
+    'zip': diz_from_zip,
+    'bz2': diz_from_bzip2,
+    'bzip2': diz_from_bzip2,
+}
+# extensions for ASCII collies
+colly_extensions = ['txt', 'asc', 'ans',]
+# decoding to use for ASCII collies
+colly_decoding = 'amiga'
+# character to denote flagged files
+flagged_char = u'+'
+# dirname for flagged listing
+flagged_dirname = u'__flagged__%s' % os.path.sep
+
+
+### script logic ###
+
+# for storing 'global' vars to be used in sub-funcs/recursive calls
+browser = {
+    'diz_location': 0,
+    'last_diz_len': 0,
+    'max_diz_width': 0,
+    'max_diz_height': 0,
+    'flagged_files': set(),
+}
+
+
+def main():
+    """
+    file browser
+
+    add support for other archive types by adding their extension and mapped
+    FILE_ID.DIZ extractor function to the `diz_extractors` dict in the
+    config section of this file
+    """
+
+    from x84.bbs import echo, getterminal, Lightbar, getch, getsession
+    from x84.bbs.ini import CFG
+
+    session, term = getsession(), getterminal()
+    session.activity = u'Browsing files'
+    root = CFG.get('sftp', 'root')
+    uploads_dir = os.path.join(root, '__uploads__')
+    # setup lightbar
+    lb_colors ={
+        'border': term.blue,
+        'highlight': term.bold_white_on_blue
+    }
+    lb = Lightbar(term.height, int(term.width * 0.25), 0, 0, colors=lb_colors)
+    # load flagged files
+    browser['flagged_files'] = session.user.get('flaggedfiles', set())
+    # remove missing files/dirs from flagged files, just in case
+    if len(browser['flagged_files']):
+        flagged = browser['flagged_files'].copy()
+        for f in browser['flagged_files']:
+            if not os.path.exists(f):
+                flagged.remove(f)
+        session.user['flaggedfiles'] = browser['flagged_files'] = flagged
+
+
+    def download_files(protocol='xmodem1k'):
+        """ download flagged files """
+
+        from x84.bbs import send_modem, recv_modem
+        if not len(browser['flagged_files']):
+            return False
+        echo(term.clear)
+        flagged = browser['flagged_files'].copy()
+        for f in flagged:
+            echo(term.bold_green(
+                u'Start your {} receiving program '
+                u'to begin transferring {}...\r\n'
+                .format(protocol, f[f.rfind(os.path.sep) + 1:])))
+            echo(u'Press ^X twice to cancel\r\n')
+            dl = open(f, 'r')
+            if not send_modem(dl, protocol):
+                echo(term.bold_red(u'Transfer failed!\r\n'))
+            else:
+                browser['flagged_files'].remove(f)
+                session.user['flaggedfiles']= browser['flagged_files']
+        echo(term.bold(u'Transfer(s) finished.\r\n'))
+        term.inkey()
+
+
+    def upload_files():
+        """ upload files """
+
+        pass
+
+
+    def draw_interface():
+        """ redraw and resize the interface """
+
+        lb.height = term.height
+        lb.width = int(term.width * 0.25)
+        # +1 for spacing between lightbar and diz
+        browser['diz_location'] = lb.width + 1
+        # -4 for lightbar borders and space before/after diz area
+        browser['max_diz_width'] = term.width - lb.width - 4
+        # -4 for space above/below diz area and info line (filename, size)
+        browser['max_diz_height'] = term.height - 4
+        echo(term.clear)
+        echo(lb.border())
+        echo(lb.refresh())
+
+
+    def clear_diz():
+        """ clear file_id.diz area """
+
+        echo(term.move(1, browser['diz_location']))
+        # +2 for info line (filename, size) and empty line below it
+        for i in range(browser['last_diz_len'] + 2):
+            echo(u''.join((
+                term.move(i, browser['diz_location']), term.clear_eol)))
+
+
+    def describe_file(diz, directory, filename, isdir=None):
+        """ describe a file in the diz area """
+
+        from common import filesize
+        description = None
+        # describe directory
+        if isdir or filename == u'..%s' % os.path.sep:
+            description = u'%s: %s' % (
+                term.bold('Directory'),
+                filename
+            )
+        # describe file
+        else:
+            fullname = os.path.join(directory, filename)
+            size = filesize(fullname)
+            description = u'%s: %s  %s: %s' % (
+                term.bold('Filename'),
+                filename[len(root):] \
+                    if directory == os.path.join(root, flagged_dirname) \
+                    else filename,
+                term.bold('Size'),
+                size,
+            )
+        echo(term.move(1, browser['diz_location']))
+        echo(description)
+        echo(term.move(3, browser['diz_location']))
+        wrapped_diz = []
+        for line in diz[:browser['max_diz_height']]:
+            wrapped_diz += term.wrap(line, browser['max_diz_width'])
+        for line in wrapped_diz:
+            browser['last_diz_len'] += 1
+            echo(term.move_x(browser['diz_location']))
+            echo(u'%s\r\n' % line)
+
+
+    def mark_flagged(directory, files):
+        """ add marker to flagged files """
+
+        files_list = list()
+        for f in files:
+            if os.path.join(directory, f) not in browser['flagged_files']:
+                files_list.append((f, u' %s' % f.strip()))
+            else:
+                files_list.append((f, u'%s%s' % (flagged_char, f.strip())))
+        return files_list
+
+
+    def flagged_listdir():
+        """ build listing for flagged files pseudo-folder """
+
+        files = [u'%s%s' % (flagged_char, f[f.rfind(os.path.sep) + 1:]) \
+            for f in browser['flagged_files']]
+        zipped_files = zip(browser['flagged_files'], files)
+        sorted_files = sorted(zipped_files, key=lambda x: x[1].lower())
+        sorted_files.insert(0, (u'..%s' % os.path.sep, u' ..%s' % os.path.sep))
+        return sorted_files
+
+
+    def regular_listdir(directory, sub):
+        """ build listing for regular folder """
+
+        files = sorted(os.listdir(directory), key=lambda x: x.lower())
+        sorted_dirs = []
+        sorted_files = []
+        for f in files:
+            fullname = os.path.join(directory, f)
+            # skip uploads folder
+            if u'sysop' not in session.user.groups and \
+                    fullname == uploads_dir:
+                continue
+            # designate dirs with path separator suffix
+            if os.path.isdir(fullname):
+                sorted_dirs.append('%s%s' % (f, os.path.sep))
+            else:
+                sorted_files.append(f)
+        # we are in a subdir; add '..' parent directory entry
+        if sub:
+            sorted_dirs.insert(0, '..%s' % os.path.sep)
+        # we are in the root; add the flagged pseudo-folder
+        else:
+            sorted_dirs.insert(0, flagged_dirname)
+        files = mark_flagged(directory, sorted_dirs + sorted_files)
+        return files
+
+
+    def browse_dir(directory, sub=False):
+        """ browse a directory """
+
+        def reload_dir():
+            """ reload contents of directory """
+
+            lb_files = set()
+            # pseudo-folder for flagged files list
+            if directory == os.path.join(root, flagged_dirname):
+                lb_files = flagged_listdir()
+            # actual folder
+            else:
+                lb_files = regular_listdir(directory, sub)
+            lb.update(lb_files)
+
+
+        def is_flagged_dir(directory):
+            """ is this our __flagged__ directory? """
+
+            return directory == flagged_dirname or \
+                    directory.endswith(flagged_dirname)
+
+
+        # build and sort directory listing
+        reload_dir()
+        echo(lb.refresh())
+        browser['last_diz_len'] = 0
+        diz = ''
+        # force it to describe the very first file when browser loads
+        inp = lb.keyset['home'][0]
+
+        while True:
+            # read from lightbar
+            while not inp:
+                inp = getch(1)
+                # respond to screen dimension change by redrawing
+                if session.poll_event('refresh'):
+                    draw_interface()
+                    describe_file(diz, directory, filename, isdir)
+            idx = lb.vitem_idx
+            shift = lb.vitem_shift
+            # pass input to lightbar
+            lb.process_keystroke(inp)
+            # lightbar 'home' keystroke bug; redraw current line
+            if inp in lb.keyset['home']:
+                echo(lb.refresh_row(idx))
+                echo(lb.refresh_row(lb.vitem_idx))
+            # 'exit' key pressed
+            elif lb.quit:
+                return False
+            # 'tag' key pressed; don't allow tagging directories
+            elif inp in (u' ',) and filename[-1:] != os.path.sep:
+                # already flagged; untag
+                if fullname in browser['flagged_files']:
+                    browser['flagged_files'].remove(fullname)
+                else:
+                    browser['flagged_files'].add(fullname)
+                session.user['flaggedfiles'] = browser['flagged_files']
+                reload_dir()
+                if is_flagged_dir(directory):
+                    echo(lb.refresh())
+                else:
+                    echo(lb.refresh_row(lb.vitem_idx))
+                    lb.move_down()
+            # 'untag all' pressed; only works in flagged files pseudo-folder
+            elif inp in (u'-',) and \
+                    is_flagged_dir(directory):
+                session.user['flaggedfiles'] = browser['flagged_files'] = set()
+                lb_files = flagged_listdir()
+                lb.update(lb_files)
+                echo(lb.refresh())
+            elif inp in (u'd',) and len(browser['flagged_files']):
+                download_files()
+                lb_files = set()
+                if is_flagged_dir(directory):
+                    lb_files = flagged_listdir()
+                else:
+                    lb_files = regular_listdir(directory, sub)
+                lb.update(lb_files)
+                echo(u''.join((term.clear, lb.border(), lb.refresh())))
+            clear_diz()
+            filename, _ = lb.selection
+            # figure out file extension
+            fullname = os.path.join(directory, filename)
+            isdir = fullname[-1:] == os.path.sep
+            ext = None
+            rfind = filename.rfind('.')
+            if rfind > -1:
+                ext = filename[rfind + 1:].lower()
+            # 'select' key pressed
+            if lb.selected or inp in (term.KEY_LEFT, term.KEY_RIGHT,):
+                # term.KEY_LEFT backs up
+                if sub and inp is term.KEY_LEFT:
+                    return True
+                # is directory
+                if (isdir or is_flagged_dir(filename)) \
+                        and (lb.selected or inp is term.KEY_RIGHT):
+                    # parent directory; back out
+                    if filename == '..%s' % os.path.sep:
+                        return True
+                    # sub directory; jump in
+                    if not browse_dir(fullname, True):
+                        return False
+                    reload_dir()
+                    lb.vitem_shift = shift
+                    lb.vitem_idx = idx
+                    echo(lb.refresh())
+            # is (supported) archive
+            elif ext in diz_extractors:
+                diz = diz_extractors[ext](fullname).split('\n')
+            # is ASCII colly, pull diz from between markers
+            elif ext in colly_extensions:
+                colly = open(fullname, 'r').read()
+                begin = '@BEGIN_FILE_ID.DIZ '
+                end = '@END_FILE_ID.DIZ'
+                pos = colly.find(begin)
+                if pos:
+                    colly = colly[pos + len(begin):]
+                    pos = colly.find(end)
+                    if pos:
+                        if session.encoding == 'utf8':
+                            diz = colly[:pos].decode(colly_decoding).split('\n')
+                        else:
+                            diz = colly[:pos].decode('cp437_art').split('\n')
+            # is pseudo-folder for flagged files
+            elif is_flagged_dir(filename):
+                diz = [
+                    u'Your flagged files',
+                    u' ',
+                    u'Press the minus (-) key while in this folder to '
+                        u'clear your list',
+                    u' ',
+                    u'Press the spacebar while browsing to flag/unflag files '
+                        u'for download',
+                ]
+            # is directory; don't give it a description
+            elif isdir:
+                diz = []
+            # is normal file
+            else:
+                diz = [u'No description']
+            browser['last_diz_len'] = len(diz)
+            describe_file(diz, directory, filename, isdir)
+            echo(lb.refresh_quick())
+            echo(lb.fixate())
+            inp = None
+
+
+    # fire it up!
+    draw_interface()
+    browse_dir(root)

--- a/x84/default/matrix_sftp.py
+++ b/x84/default/matrix_sftp.py
@@ -1,0 +1,59 @@
+"""
+SFTP Matrix for X/84 (Formerly, 'The Progressive') BBS,
+
+This script is the default session entry point for all sftp connections.
+
+Nothing especially cute going on here yet.  Ultimately we'd like
+a single-directioned communication from x84.sftp.X84SFTPServer
+so that we can be notified of the user activity.  We need to make
+sure to ensure certain kinds of events are ignored or not handled,
+also.
+
+It is *especially* important *never* to echo anything to the
+client.  We are still able to push bytes through, though we should
+not and allow the sftp subsystem handler to do that for us.
+
+Also, anonymous and new users are not well-handled, here.
+
+In order to configure x/84 as an SFTP server, you will need to add an [sftp]
+section to your default.ini file and add a `root` option. This points to the
+location of your SFTP server's root directory. Within that directory, ensure
+that there is a directory named `__uploads__`.
+"""
+
+# std imports
+import logging
+
+
+def main(anonymous=False, new=False, username=''):
+    """ Main procedure. """
+    from x84.bbs import (
+        getsession,
+        getterminal,
+        find_user,
+        get_user,
+        User,
+    )
+
+    session, term = getsession(), getterminal()
+    session.activity = 'sftp'
+
+    if anonymous:
+        user = User(u'anonymous')
+    else:
+        assert not new, ("new@ user not supported by SFTP.")
+
+        # ProperCase user-specified handle
+        handle = find_user(username)
+        assert handle is not None, handle
+
+        # fetch user record
+        user = get_user(handle)
+
+    # assign session user, just as top.py function login()
+    session.user = user
+
+    while True:
+        inp = term.inkey()  # should block indefinately
+        log = logging.getLogger(__name__)
+        log.warn('Got inkey: {0!r}'.format(inp))

--- a/x84/sftp.py
+++ b/x84/sftp.py
@@ -1,0 +1,324 @@
+"""
+SFTP server for x/84 bbs https://github.com/jquast/x84
+
+In order to configure x/84 as an SFTP server, you will need to add an [sftp]
+section to your default.ini file and add a `root` option. This points to the
+location of your SFTP server's root directory. Within that directory, ensure
+that there is a directory named `__uploads__`.
+
+This is based on paramiko's `StubSFTPServer` implementation.
+"""
+
+# std imports
+import logging
+import os
+
+# 3rd-party
+from paramiko import (
+    SFTPServerInterface,
+    SFTPServer,
+    SFTPAttributes,
+    SFTPHandle,
+    SFTP_OK,
+    SFTP_PERMISSION_DENIED,
+)
+
+# directory name for flagged files
+flagged_dirname = '__flagged__'
+uploads_dirname = '__uploads__'
+
+
+class X84SFTPHandle (SFTPHandle):
+
+    def __init__(self, *args, **kwargs):
+        self.log = logging.getLogger('x84.engine')
+        self.user = kwargs.pop('user')
+        super(X84SFTPHandle, self).__init__(*args, **kwargs)
+
+
+    def stat(self):
+        self.log.debug('stat')
+        try:
+            return SFTPAttributes.from_stat(os.fstat(self.readfile.fileno()))
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+
+
+    def chattr(self, attr):
+        if not self.user.is_sysop:
+            return SFTP_PERMISSION_DENIED
+        self.log.debug('chattr ({0!r})'.format(attr))
+        # python doesn't have equivalents to fchown or fchmod, so we have to
+        # use the stored filename
+        try:
+            SFTPServer.set_file_attr(self.filename, attr)
+            return SFTP_OK
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+
+
+class X84SFTPServer (SFTPServerInterface):
+    from x84.bbs.ini import CFG
+    ROOT = CFG.get('sftp', 'root')
+    UMASK = 0o644
+
+    def __init__(self, *args, **kwargs):
+        from x84.bbs import DBProxy
+        from x84.bbs.ini import CFG
+        if CFG.has_option('sftp', 'umask'):
+            self.UMASK = int('0o{0}'.format(CFG.get('sftp', 'umask')), 8)
+        self.ssh_session = kwargs.pop('session')
+        username = self.ssh_session.username
+        userdb = DBProxy('userbase', use_session=False)
+        self.user = None
+        with userdb:
+            self.user = userdb[username]
+        self.flagged = self.user.get('flaggedfiles', set())
+        self.log = logging.getLogger('x84.engine')
+        super(X84SFTPServer, self).__init__(*args) #, **kwargs)
+
+
+    def _dummy_dir_stat(self):
+        self.log.debug('_dummy_dir_stat')
+        attr = SFTPAttributes.from_stat(
+                os.stat(self.ROOT))
+        attr.filename = flagged_dirname
+        return attr
+
+
+    def _realpath(self, path):
+        self.log.debug('_realpath({0!r})'.format(path))
+        if path.endswith(flagged_dirname):
+            self.log.debug('fake dir path: {0!r}'.format(path))
+            return self.ROOT + path
+        elif path.find(flagged_dirname) > -1:
+            self.log.debug('fake file path: {0!r}'.format(path))
+            for f in self.flagged:
+                fstripped = f[f.rindex(os.path.sep) + 1:]
+                pstripped = path[path.rindex('/') + 1:]
+                if fstripped == pstripped:
+                    self.log.debug('file is actually {0}'.format(f))
+                    return f
+        return self.ROOT + self.canonicalize(path)
+
+
+    def _is_uploaddir(self, path):
+        return ('/{0}'.format(path) == uploads_dirname)
+
+
+    def list_folder(self, path):
+        self.log.debug('list_folder({0!r})'.format(path))
+        rpath = self._realpath(path)
+        if not self.user.is_sysop and self._is_uploaddir(path):
+            return []
+        try:
+            out = []
+            if path == u'/':
+                out.append(self._dummy_dir_stat())
+            elif flagged_dirname in path:
+                for fname in self.flagged:
+                    rname = fname
+                    attr = SFTPAttributes.from_stat(os.stat(rname))
+                    attr.filename = fname[fname.rindex('/') + 1:]
+                    out.append(attr)
+                return out
+            flist = os.listdir(rpath)
+            for fname in flist:
+                attr = SFTPAttributes.from_stat(
+                    os.stat(os.path.join(rpath, fname)))
+                attr.filename = fname
+                out.append(attr)
+            return out
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+
+
+    def stat(self, path):
+        self.log.debug('stat({0!r})'.format(path))
+        if path.endswith(flagged_dirname):
+            return self._dummy_dir_stat()
+        elif path.find(flagged_dirname) > -1:
+            for f in self.flagged:
+                fstripped = f[f.rindex(os.path.sep) + 1:]
+                pstripped = path[path.rindex('/') + 1:]
+                if fstripped == pstripped:
+                    self.log.debug('file is actually {0}'.format(f))
+                    return SFTPAttributes.from_stat(f)
+        path = self._realpath(path)
+        try:
+            return SFTPAttributes.from_stat(os.stat(path))
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+
+
+    def lstat(self, path):
+        self.log.debug('lstat({0!r})'.format(path))
+        if path.endswith(flagged_dirname):
+            return self._dummy_dir_stat()
+        elif path.find(flagged_dirname) > -1:
+            for f in self.flagged:
+                fstripped = f[f.rindex(os.path.sep) + 1:]
+                pstripped = path[path.rindex('/') + 1:]
+                if fstripped == pstripped:
+                    self.log.debug('file is actually {0}'.format(f))
+                    return SFTPAttributes.from_stat(f)
+        path = self._realpath(path)
+        try:
+            return SFTPAttributes.from_stat(os.lstat(path))
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+
+
+    def open(self, path, flags, attr):
+        self.log.debug('lstat({0!r}, {1!r}, {2!r})'
+                       .format(path, flags, attr))
+        path = self._realpath(path)
+        if flags & os.O_CREAT and (uploads_dirname not in path and \
+                not self.user.is_sysop) or \
+                (uploads_dirname in path and os.path.exists(path)):
+            return SFTP_PERMISSION_DENIED
+        try:
+            binary_flag = getattr(os, 'O_BINARY',  0)
+            flags |= binary_flag
+            fd = os.open(path, flags, self.UMASK)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        if (flags & os.O_CREAT) and (attr is not None):
+            attr._flags &= ~attr.FLAG_PERMISSIONS
+            SFTPServer.set_file_attr(path, attr)
+        if flags & os.O_WRONLY:
+            if flags & os.O_APPEND:
+                fstr = 'ab'
+            else:
+                fstr = 'wb'
+        elif flags & os.O_RDWR:
+            if flags & os.O_APPEND:
+                fstr = 'a+b'
+            else:
+                fstr = 'r+b'
+        else:
+            # O_RDONLY (== 0)
+            fstr = 'rb'
+        try:
+            f = os.fdopen(fd, fstr)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        fobj = X84SFTPHandle(flags, user=self.user)
+        fobj.filename = path
+        fobj.readfile = f
+        fobj.writefile = f
+
+        if path in self.flagged:
+            self.flagged.remove(path)
+            self.user['flaggedfiles'] = self.flagged
+        return fobj
+
+
+    def remove(self, path):
+        if not self.user.is_sysop or flagged_dirname in path:
+            return SFTP_PERMISSION_DENIED
+        self.log.debug('remove({0!r})'.format(path))
+        path = self._realpath(path)
+        try:
+            os.remove(path)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        return SFTP_OK
+
+
+    def rename(self, oldpath, newpath):
+        if not self.user.is_sysop or flagged_dirname in path:
+            return SFTP_PERMISSION_DENIED
+        self.log.debug('rename({0!r}, {1!r})'.format(oldpath, newpath))
+        oldpath = self._realpath(oldpath)
+        newpath = self._realpath(newpath)
+        try:
+            os.rename(oldpath, newpath)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        return SFTP_OK
+
+
+    def mkdir(self, path, attr):
+        if not self.user.is_sysop or flagged_dirname in path:
+            return SFTP_PERMISSION_DENIED
+        self.log.debug('mkdir({0!r}, {1!r})'.format(path, attr))
+        path = self._realpath(path)
+        try:
+            os.mkdir(path)
+            if attr is not None:
+                SFTPServer.set_file_attr(path, attr)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        return SFTP_OK
+
+
+    def rmdir(self, path):
+        if not self.user.is_sysop or flagged_dirname in path:
+            return SFTP_PERMISSION_DENIED
+        self.log.debug('rmdir({0!r})'.format(path))
+        path = self._realpath(path)
+        try:
+            os.rmdir(path)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        return SFTP_OK
+
+
+    def chattr(self, path, attr):
+        if self._is_uploaddir(path):
+            return SFTP_PERMISSION_DENIED
+        elif not self.user.is_sysop or \
+                uploads_dirname in path or \
+                flagged_dirname in path:
+            return SFTP_PERMISSION_DENIED
+        self.log.debug('chattr({0!r})'.format(path))
+        path = self._realpath(path)
+        try:
+            SFTPServer.set_file_attr(path, attr)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        return SFTP_OK
+
+
+    def symlink(self, target_path, path):
+        if not self.user.is_sysop or flagged_dirname in path:
+            return SFTP_PERMISSION_DENIED
+        self.log.debug('symlink({0!r}, {1!r})'.format(target_path, path))
+        path = self._realpath(path)
+        if (len(target_path) > 0) and (target_path[0] == '/'):
+            # absolute symlink
+            target_path = os.path.join(self.ROOT, target_path[1:])
+            if target_path[:2] == '//':
+                # bug in os.path.join
+                target_path = target_path[1:]
+        else:
+            # compute relative to path
+            abspath = os.path.join(os.path.dirname(path), target_path)
+            if abspath[:len(self.ROOT)] != self.ROOT:
+                # this symlink isn't going to work anyway
+                # -- just break it immediately
+                target_path = '<error>'
+        try:
+            os.symlink(target_path, path)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        return SFTP_OK
+
+
+    def readlink(self, path):
+        self.log.debug('readlink({0!r})'.format(path))
+        path = self._realpath(path)
+        try:
+            symlink = os.readlink(path)
+        except OSError as err:
+            return SFTPServer.convert_errno(err.errno)
+        # if it's absolute, remove the root
+        if os.path.isabs(symlink):
+            if symlink[:len(self.ROOT)] == self.ROOT:
+                symlink = symlink[len(self.ROOT):]
+                if (len(symlink) == 0) or (symlink[0] != '/'):
+                    symlink = '/' + symlink
+            else:
+                symlink = '<error>'
+        return symlink


### PR DESCRIPTION
## configuration

to configure sftp server:
- add `[sftp]` section to `default.ini`
- add `root` option to `[sftp]` section, pointing at root folder for files
- (optionally) add `umask` option to `[sftp]` section for default umask on uploaded files

to enable uploads:
- create `__uploads__` directory in sftp root

to enable file browser:
- add menu option for `gosub('fbrowse')`
## things to add
- `FILE_ID.DIZ` caching, but that seems like premature optimization at this point
- ability to enter manual descriptions for files (will depend on same storage mechanism that holds `FILE_ID.DIZ` cache)
- virtual `FILES.BBS` generation so that sftp clients can view descriptions of a folder's files without being logged in via terminal server
- integration with x/84's IPC logging mechanism
- better detection of file download completion (currently, file is removed from user's tagged list as soon as it is opened via sftp, rather than when it is finished)
- tracking uploads/downloads (i.e., who uploaded what, how many times has something been downloaded, who downloaded what, etc.)
## notes
- this adds `filesize` to `common.py` for a human-readable file size function as per #146
