### PR TITLE
fbrowse adjustments for tiny screens

### DIFF
--- a/x84/bbs/lightbar.py
+++ b/x84/bbs/lightbar.py
@@ -116,7 +116,7 @@ class Lightbar(AnsiWindow):
 
         def fit_row(ucs):
             """ Strip a unicode row to fit window boundry, if necessary """
-            column = self.visible_width + 1
+            column = self.visible_width - 1
             wrapped = term.wrap(ucs, column)
             if len(wrapped) > 1:
                 marker = self.glyphs.get('strip', u' $')

--- a/x84/default/fbrowse.py
+++ b/x84/default/fbrowse.py
@@ -226,8 +226,8 @@ def draw_interface(term, lightbar):
     lightbar.width = max(10, int(term.width * 0.25))
     # +1 for spacing between lightbar and diz
     browser.diz_location = lightbar.width + 1
-    # -4 for lightbar borders and space before/after diz area
-    browser.max_diz_width = term.width - lightbar.width - 4
+    # -2 for spacing between the lightbar, the diz, and the edge of the screen
+    browser.max_diz_width = term.width - lightbar.width - 2
     # -4 for space above/below diz area and info line (filename, size)
     browser.max_diz_height = term.height - 4
     echo(u''.join([term.clear,
@@ -264,13 +264,17 @@ def describe_file(term, diz, directory, filename, isdir=None):
                                txt_Size=term.bold(u'Size'),
                                size=_size))
 
+    description = term.wrap(description, browser.max_diz_width)
     echo(u''.join((term.move(1, browser.diz_location),
-                   description,
-                   term.move(3, browser.diz_location))))
+                   u''.join(['{0}{1}\r\n'.format(
+                             term.move_x(browser.diz_location), line)
+                             for line in description]),
+                   term.move(2 + len(description), browser.diz_location))))
 
     wrapped_diz = []
-    for line in diz[:browser.max_diz_height]:
+    for line in diz:
         wrapped_diz += term.wrap(line, browser.max_diz_width)
+    wrapped_diz = wrapped_diz[:browser.max_diz_height - len(description) + 1]
 
     output = u''
     for line in wrapped_diz:


### PR DESCRIPTION
* fixes `fbrowse.py` bug for #171 
* also fixes a bug in `lightbar.py` that wasn't correctly trimming entries that were 1 char wider than the lightbar's interior