### PR TITLE
revert syncterm, ._rows, ._columns is private

### DIFF
--- a/x84/bbs/door.py
+++ b/x84/bbs/door.py
@@ -857,7 +857,7 @@ def launch(dos=None, cp437=True, drop_type=None,
 
                     # hand-hack, its ok ... really
                     store_cols, store_rows = term.width, term.height
-                    term.columns, term.rows = want_cols, want_rows
+                    term._columns, term._rows = want_cols, want_rows
                     term.inkey(timeout=1)
 
             if activity is not None:
@@ -894,9 +894,10 @@ def launch(dos=None, cp437=True, drop_type=None,
                             env_term=env_term)
 
             door.run()
+
         finally:
             if store_rows is not None and store_cols is not None:
-                term.rows, term.columns = store_rows, store_cols
+                term._rows, term._columns = store_rows, store_cols
                 echo(u'\x1b[8;%d;%dt' % (store_rows, store_cols,))
                 term.inkey(timeout=0.25)
 

--- a/x84/bbs/ini.py
+++ b/x84/bbs/ini.py
@@ -224,6 +224,7 @@ def init_bbs_ini():
     cfg_bbs.set('irc', 'server', 'irc.efnet.org')
     cfg_bbs.set('irc', 'port', '6667')
     cfg_bbs.set('irc', 'channel', '#1984')
+    cfg_bbs.set('irc', 'maxnick', '9')
     cfg_bbs.set('irc', 'ssl', 'no')
 
     cfg_bbs.add_section('shroo-ms')

--- a/x84/bbs/session.py
+++ b/x84/bbs/session.py
@@ -548,7 +548,7 @@ class Session(object):
         if event == 'refresh':
             if data[0] == 'resize':
                 # inherit terminal dimensions values
-                (self.terminal.columns, self.terminal.rows) = data[1]
+                (self.terminal._columns, self.terminal._rows) = data[1]
 
         # buffer all else
         self._buffer[event].appendleft(data)

--- a/x84/default/ircchat.py
+++ b/x84/default/ircchat.py
@@ -1,18 +1,5 @@
-"""
-IRC chat script for x/84 bbs, https://github.com/jquast/x84
+""" IRC chat script for x/84. """
 
-To use something other than the default values, add an [irc] section to your
-configuration file and assign it a server, port, and channel, like so:
-
-default.ini
----
-[irc]
-server = irc.shaw.ca
-port = 6697
-channel = #1984
-max_nick = 9
-enable_ssl = True
-"""
 # std imports
 import collections
 import warnings
@@ -47,7 +34,7 @@ CHANNEL = get_ini('irc', 'channel') or '#1984'
 MAX_NICK = get_ini('irc', 'max_nick', getter='getint') or 9
 
 #: whether irc server requires ssl
-ENABLE_SSL = get_ini('irc', 'enable_ssl', getter='getboolean')
+ENABLE_SSL = get_ini('irc', 'ssl', getter='getboolean')
 
 #: Whether to display PRIVNOTICE messages (such as motd)
 ENABLE_PRIVNOTICE = get_ini('irc', 'enable_privnotice', getter='getboolean')
@@ -471,10 +458,10 @@ def refresh_event(term, scrollback, editor):
             break
     output = output[numlines * -1:]
     echo(u''.join([
-                   term.normal, term.home, term.clear_eos,
-                   term.move(editor.yloc + 1, 0),
-                   u'\r\n'.join(output),
-                   u'\r\n', editor.refresh()]))
+        term.normal, term.home, term.clear_eos,
+        term.move(editor.yloc + 1, 0),
+        u'\r\n'.join(output),
+        u'\r\n', editor.refresh()]))
 
 
 def irc_event(term, data, scrollback, editor):

--- a/x84/default/lord.py
+++ b/x84/default/lord.py
@@ -74,7 +74,7 @@ def main():
             term.width, term.height, want_cols, want_rows,))
         # hand-hack, its ok ... really
         store_cols, store_rows = term.width, term.height
-        term.columns, term.rows = want_cols, want_rows
+        term._columns, term._rows = want_cols, want_rows
         term.inkey(1)
 
     session.activity = 'Playing LORD'

--- a/x84/default/sesame.py
+++ b/x84/default/sesame.py
@@ -65,7 +65,7 @@ def main(name):
                 term.width, term.height, want_cols, want_rows,))
             # hand-hack, its ok ... really
             store_cols, store_rows = term.width, term.height
-            term.columns, term.rows = want_cols, want_rows
+            term._columns, term._rows = want_cols, want_rows
             term.inkey(1)
 
     except ConfigParser.NoOptionError:
@@ -109,6 +109,6 @@ def main(name):
     echo(term.clear)
     if not (store_cols is None and store_rows is None):
         echo(u'Restoring dimensions to %s by %s !' % (store_cols, store_rows))
-        term.rows, term.columns = store_rows, store_cols
+        term._rows, term._columns = store_rows, store_cols
     echo(u'\r\n')
     term.inkey(0.5)

--- a/x84/terminal.py
+++ b/x84/terminal.py
@@ -14,8 +14,8 @@ class Terminal(BlessedTerminal):
     _session = None
 
     def __init__(self, kind, stream, rows, columns):
-        self.rows = rows
-        self.columns = columns
+        self._rows = rows
+        self._columns = columns
         BlessedTerminal.__init__(self, kind, stream)
         if sys.platform.lower().startswith('win32'):
             self._normal = '\x1b[m'
@@ -65,26 +65,7 @@ class Terminal(BlessedTerminal):
 
     def _height_and_width(self):
         from blessed.terminal import WINSZ
-        _rows = self.rows
-        if (self.kind.startswith('ansi') and
-                self.columns == 80 and _rows in (24, 25)):
-            # All other teminal emulators, you can write 'x' at
-            # (0, 0) and (height, width), and both x's will appear.
-            #
-            # Not so on SyncTerm. This will cause it to scroll: twice.
-            #
-            # Once, because it misinterprets the 0-based nature of
-            # cursor movement, and the final line causes scroll --
-            # Twice, because writing to the final column of the final
-            # line causes yet another scroll.
-            #
-            # For this reason, it is not recommended to ever write to
-            # the final 2 lines of SyncTerm, which really just appears
-            # to the user as the final 1 line.
-            #
-            # https://github.com/jquast/x84/issues/188
-            _rows -= 2
-        return WINSZ(ws_row=_rows, ws_col=self.columns,
+        return WINSZ(ws_row=self._rows, ws_col=self._columns,
                      ws_xpixel=None, ws_ypixel=None)
     _height_and_width.__doc__ = BlessedTerminal._height_and_width.__doc__
 


### PR DESCRIPTION
Discovered some abuses of accessing .rows and .columns
directly; it should not -- term.height and term.width
is the official api property accessors.

also, revert the syncterm height workaround, syncterm
will just have to be fucked, so let it. I can't help
that its wrong.