### PR TITLE
relax tag name search for location in accuweather response

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 2.0.7
+  - bugfix: XML element tag name in weather.py AccuWeather response now
+    includes namespace
   - bugfix: ValueError in profile.py for setting bad timeout value
   - bugfix: ASCII colly diz with extended chars was causing an error
   - bugfix: KeyError in hackernews.py

--- a/x84/default/weather.py
+++ b/x84/default/weather.py
@@ -153,7 +153,7 @@ def do_search(term, search):
         xml_stream = StringIO.StringIO(resp.content)
         locations = list([dict(elem.attrib.items())
                           for _, elem in ET.iterparse(xml_stream)
-                          if elem.tag == 'location'])
+                          if 'location' in elem.tag])
         if 0 == len(locations):
             disp_notfound()
         else:


### PR DESCRIPTION
`ET.iterparse` now seems to include the namespace in the element's tag name when parsing an XML stream (or perhaps apple recently added the namespace); each search was defaulting to the user's saved location when it couldn't find any results in the XML response from AccuWeather.