### PR TITLE
allow profile.py to take handle as arg

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+2.0.9
+  - bugfix: profile.py now accepts a target handle as an optional
+    argument to its main() function, so online.py can successfully
+    launch the profile editor for online users.
 2.0.8
   - bugfix: Fixed a nasty Return value bug in vote.py that could
     cause a database failure.

--- a/x84/default/online.py
+++ b/x84/default/online.py
@@ -132,7 +132,7 @@ def edit(sessions):
     from x84.bbs import gosub
     (node, tgt_session) = get_node(sessions)
     if node is not None:
-        gosub('profile', tgt_session['handle'])
+        gosub('profile', handle=tgt_session['handle'])
         return True
 
 

--- a/x84/default/profile.py
+++ b/x84/default/profile.py
@@ -497,11 +497,11 @@ def get_next_user(tgt_user):
         return get_user(handles[idx - 1])
 
 
-def main():
+def main(handle=None):
     """ Main procedure. """
     dirty = -1
     session, term = getsession(), getterminal()
-    tgt_user = session.user
+    tgt_user = get_user(handle) if handle else session.user
     legal_input_characters = string.letters + u'<>'
 
     # re-display entire screen on loop,


### PR DESCRIPTION
`online.py` expected `profile.py` to take a handle as an argument to its `main()` function, but the method signature didn't match. Hat tip to @crb02005 for spotting the bug.