### PR TITLE
Fix for x84 issue #235.

### DIFF
--- a/x84/default/ol.py
+++ b/x84/default/ol.py
@@ -491,7 +491,7 @@ def do_prompt(term, session):
                         # user has said something to the local database,
                         # refresh it so that they can beam with pride ...
                         dirty = 1
-                        continue
+                        break
 
                     # only redraw prompt (user canceled)
                     dirty = 2


### PR DESCRIPTION
This fixes the ol.py redraw issue reported in https://github.com/jquast/x84/issues/235 . With ``dirty == 1`` we break out of the inner while loop and return to the while not do_quit logic. Which forces a redraw of the oneliners.