### PR TITLE
Tetris and Weather Fixups

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+2.0.11
+  - bugfix: weather.py fix incorrect postal code return from Accu Weather.
+    Changed the default to populate search by city/state instead of 
+    postal since this is no longer returned from accu weather correctly.
+    Also re-added missing save location field that was outside of 
+    while loop to funtion exit.
+  - bugfix: tetris.py fix for sending terminal font sequence prior to 
+    ansi screen display instead of after.
 2.0.10
   - bugfix: display updates when posting to oneliners, issue #235
 

--- a/x84/default/tetris.py
+++ b/x84/default/tetris.py
@@ -312,7 +312,7 @@ def play():
     getch()
     # set syncterm font to cp437
     if term.kind.startswith('ansi'):
-        echo(syncterm_setfont('cp437'))
+        echo_unbuffered(syncterm_setfont('cp437'))
     artfile = os.path.join(os.path.dirname(__file__), 'art', 'tetris.ans')
     echo_unbuffered(u'\r\n' * term.height)  # cls
     if os.path.exists(artfile):

--- a/x84/default/weather.py
+++ b/x84/default/weather.py
@@ -158,6 +158,7 @@ def do_search(term, search):
             disp_notfound()
         else:
             disp_found(len(locations))
+
     return locations
 
 
@@ -509,7 +510,7 @@ def main():
     while True:
         echo(u'\r\n\r\n')
         location = session.user.get('location', dict())
-        search = location.get('postal', u'')
+        search = location.get('city', u'') + ', ' + location.get('state', u'')
         disp_search_help()
         search = get_zipsearch(search)
         if search is None or 0 == len(search):
@@ -517,6 +518,7 @@ def main():
             return
 
         locations = do_search(term, search)
+
         if 0 != len(locations):
             location = (locations.pop() if 1 == len(locations)
                         else chose_location(locations) or dict())
@@ -552,6 +554,6 @@ def main():
                     get_centigrade()
                     break
                 elif inp.code == term.KEY_ENTER:
+                    chk_save_location(location)
                     return
 
-    chk_save_location(location)


### PR DESCRIPTION
Summary tetris.py
echo(syncterm_setfont('cp437'))  to
echo_unbuffered(syncterm_setfont('cp437'))  Original buffered settings
makes this command output after the ANSI screen is drawn. It should push
out prior to displaying the ANSI screen.

Summary weather.py
1. loop was not saving new searches or prompting the user to save
because it was outside of the loop.  This affected current users since
it was not updating and only retrieving their last save.  And affected
new users because it would never save a new location.

2. Once this was fixed I noticed Accu Weather API doesn't return postal
code anymore on findcity.  This is causing the get.location to retrieve
a bad value on postal lookup for pre-populating the search field.
Changing this to City, State lookup solves the issues and looks nice
too.