### PR TITLE
msgarea.py group members ability to read messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+2.0.12
+  - bugfix: msgarea.py group members were not able to see private messages
+    assigned with their group tag. for example [sysop], if someone posted a
+    public message with only a sysop tag and/or private tag, no one in the group
+    was able to read it because private messages were not group tag checking
+    when being excluded from a users view.
 2.0.11
   - bugfix: weather.py fix incorrect postal code return from Accu Weather.
     Changed the default to populate search by city/state instead of 

--- a/x84/default/msgarea.py
+++ b/x84/default/msgarea.py
@@ -140,6 +140,10 @@ def get_messages_by_subscription(session, subscription):
     messages_bytag = {}
     messages_read = session.user.get('readmsgs', set())
 
+    # now occlude all private messages :)
+    # get this first so that we can skip groups that users are members of.
+    all_private = list_privmsgs(None)
+
     # this looks like perl code
     for tag_pattern in subscription:
         messages_bytag[tag_pattern] = collections.defaultdict(set)
@@ -147,20 +151,21 @@ def get_messages_by_subscription(session, subscription):
             msg_indicies = list_msgs(tags=(tag_match,))
             messages['all'].update(msg_indicies)
             messages_bytag[tag_pattern]['all'].update(msg_indicies)
+
+            if tag_match not in session.user.groups:
+                # If where not in a group, exclude all private messages!
+                # Check this on Tag by Tag Basis
+                # Otherwise group members see no messages!
+                messages['all'] -= all_private
+
         messages_bytag[tag_pattern]['new'] = (
             messages_bytag[tag_pattern]['all'] - messages_read)
-
-    # now occlude all private messages :)
-    all_private = list_privmsgs(None)
-    messages['new'] -= all_private
-    messages['all'] -= all_private
 
     # and make a list of only our own
     messages['private'] = list_privmsgs(session.user.handle)
 
     # and calculate 'new' messages
     messages['new'] = (messages['all'] | messages['private']) - messages_read
-
     return messages, messages_bytag
 
 

--- a/x84/default/msgarea.py
+++ b/x84/default/msgarea.py
@@ -157,6 +157,10 @@ def get_messages_by_subscription(session, subscription):
                 # Check this on Tag by Tag Basis
                 # Otherwise group members see no messages!
                 messages['all'] -= all_private
+            else:
+                # Remove group private messages so we don't
+                # remove on next tag_match loop.
+                all_private -= msg_indicies
 
         messages_bytag[tag_pattern]['new'] = (
             messages_bytag[tag_pattern]['all'] - messages_read)


### PR DESCRIPTION
- bugfix: msgarea.py group members were not able to see or read private messages assigned with their group tag. for example [sysop], if someone posted a public message with only a sysop tag and/or private tag, no one in the group was able to read it because private messages were not group tag checked when being excluded from a users view.