### PR TITLE
deprecate the use of 'getch()'

### DIFF
--- a/x84/bbs/editor.py
+++ b/x84/bbs/editor.py
@@ -395,20 +395,25 @@ class ScrollingEditor(AnsiWindow):
         """
         self._quit = False
         rstr = u''
-        keystroke = hasattr(keystroke, 'code') and keystroke.code or keystroke
-        if keystroke in self.keyset['refresh']:
+        if (keystroke in self.keyset['refresh'] or
+                keystroke.code in self.keyset['refresh']):
             rstr = self.refresh()
-        elif keystroke in self.keyset['backspace']:
+        elif (keystroke in self.keyset['backspace'] or
+              keystroke.code in self.keyset['backspace']):
             rstr = self.backspace()
-        elif keystroke in self.keyset['backword']:
+        elif (keystroke in self.keyset['backword'] or
+              keystroke.code in self.keyset['backword']):
             rstr = self.backword()
-        elif keystroke in self.keyset['enter']:
+        elif (keystroke in self.keyset['enter'] or
+              keystroke.code in self.keyset['enter']):
             self._carriage_returned = True
             rstr = u''
-        elif keystroke in self.keyset['exit']:
+        elif (keystroke in self.keyset['exit'] or
+              keystroke.code in self.keyset['exit']):
             self._quit = True
             rstr = u''
-        elif isinstance(keystroke, int):
+        elif keystroke.is_sequence:
+            # could beep also, (error)
             rstr = u''
         else:
             if ord(keystroke) >= 0x20:

--- a/x84/bbs/editor.py
+++ b/x84/bbs/editor.py
@@ -424,6 +424,7 @@ class ScrollingEditor(AnsiWindow):
         echo(self.refresh())
         self._quit = False
         self._carriage_returned = False
+        term = getterminal()
         while not (self.quit or self.carriage_returned):
             inp = term.inkey()
             echo(self.process_keystroke(inp))

--- a/x84/bbs/editor.py
+++ b/x84/bbs/editor.py
@@ -11,7 +11,7 @@ import warnings
 
 # local
 from x84.bbs.ansiwin import AnsiWindow, GLYPHSETS
-from x84.bbs.session import getterminal, getch
+from x84.bbs.session import getterminal
 from x84.bbs.output import echo
 
 #: default command-key mapping.
@@ -189,7 +189,7 @@ class LineEditor(object):
         self._quit = False
         echo(self.refresh())
         while not (self.quit or self.carriage_returned):
-            inp = getch()
+            inp = term.inkey()
             echo(self.process_keystroke(inp))
         echo(self._term.normal)
         if not self.quit:
@@ -424,7 +424,7 @@ class ScrollingEditor(AnsiWindow):
         self._quit = False
         self._carriage_returned = False
         while not (self.quit or self.carriage_returned):
-            inp = getch()
+            inp = term.inkey()
             echo(self.process_keystroke(inp))
         if not self.quit:
             return self.content

--- a/x84/bbs/editor.py
+++ b/x84/bbs/editor.py
@@ -188,6 +188,7 @@ class LineEditor(object):
         self._carriage_returned = False
         self._quit = False
         echo(self.refresh())
+        term = getterminal()
         while not (self.quit or self.carriage_returned):
             inp = term.inkey()
             echo(self.process_keystroke(inp))

--- a/x84/bbs/lightbar.py
+++ b/x84/bbs/lightbar.py
@@ -2,7 +2,7 @@
 
 # local imports
 from x84.bbs.ansiwin import AnsiWindow
-from x84.bbs.session import getterminal, getch
+from x84.bbs.session import getterminal
 from x84.bbs.output import decode_pipe, echo
 
 
@@ -218,8 +218,9 @@ class Lightbar(AnsiWindow):
         self._selected = False
         self._quit = False
         echo(self.refresh())
+        term = getterminal()
         while not (self.selected or self.quit):
-            echo(self.process_keystroke(getch()))
+            echo(self.process_keystroke(term.inkey()))
         if self.quit:
             return None
         return self.selection[0]

--- a/x84/bbs/lightbar.py
+++ b/x84/bbs/lightbar.py
@@ -177,7 +177,7 @@ class Lightbar(AnsiWindow):
                 return (self.refresh_row(self.vitem_idx))
         return u''
 
-    def process_keystroke(self, key):
+    def process_keystroke(self, keystroke):
         """
         Process the keystroke and return string to refresh.
 
@@ -190,22 +190,29 @@ class Lightbar(AnsiWindow):
         self._vitem_lastidx = self.vitem_idx
         self._vitem_lastshift = self.vitem_shift
         rstr = u''
-        keystroke = hasattr(key, 'code') and key.code or key
-        if keystroke in self.keyset['home']:
+        if (keystroke in self.keyset['home'] or
+                keystroke.code in self.keyset['home']):
             rstr = self.move_home()
-        elif keystroke in self.keyset['end']:
+        elif (keystroke in self.keyset['end'] or
+              keystroke.code in self.keyset['end']):
             rstr = self.move_end()
-        elif keystroke in self.keyset['pgup']:
+        elif (keystroke in self.keyset['pgup'] or
+              keystroke.code in self.keyset['pgup']):
             rstr = self.move_pageup()
-        elif keystroke in self.keyset['pgdown']:
+        elif (keystroke in self.keyset['pgdown'] or
+              keystroke.code in self.keyset['pgdown']):
             rstr = self.move_pagedown()
-        elif keystroke in self.keyset['up']:
+        elif (keystroke in self.keyset['up'] or
+              keystroke.code in self.keyset['up']):
             rstr = self.move_up()
-        elif keystroke in self.keyset['down']:
+        elif (keystroke in self.keyset['down'] or
+              keystroke.code in self.keyset['down']):
             rstr = self.move_down()
-        elif keystroke in self.keyset['enter']:
+        elif (keystroke in self.keyset['enter'] or
+              keystroke.code in self.keyset['enter']):
             self.selected = True
-        elif keystroke in self.keyset['exit']:
+        elif (keystroke in self.keyset['exit'] or
+              keystroke.code in self.keyset['exit']):
             self._quit = True
         return rstr
 

--- a/x84/bbs/pager.py
+++ b/x84/bbs/pager.py
@@ -1,7 +1,7 @@
 """ Pager package for x/84. """
 from x84.bbs.ansiwin import AnsiWindow
 from x84.bbs.output import encode_pipe, decode_pipe
-from x84.bbs.session import getterminal, getch
+from x84.bbs.session import getterminal
 from x84.bbs.output import echo
 
 VI_KEYSET = {
@@ -136,8 +136,9 @@ class Pager(AnsiWindow):
         """
         self._quit = False
         echo(self.refresh())
+        term = getterminal()
         while not self.quit:
-            echo(self.process_keystroke(getch()))
+            echo(self.process_keystroke(term.inkey()))
 
     def move_home(self):
         """

--- a/x84/bbs/pager.py
+++ b/x84/bbs/pager.py
@@ -106,22 +106,29 @@ class Pager(AnsiWindow):
         """
         self.moved = False
         rstr = u''
-        keystroke = hasattr(keystroke, 'code') and keystroke.code or keystroke
-        if keystroke in self.keyset['refresh']:
+        if (keystroke in self.keyset['refresh'] or
+                keystroke.code in self.keyset['refresh']):
             rstr += self.refresh()
-        elif keystroke in self.keyset['up']:
+        elif (keystroke in self.keyset['up'] or
+              keystroke.code in self.keyset['up']):
             rstr += self.move_up()
-        elif keystroke in self.keyset['down']:
+        elif (keystroke in self.keyset['down'] or
+              keystroke.code in self.keyset['down']):
             rstr += self.move_down()
-        elif keystroke in self.keyset['home']:
+        elif (keystroke in self.keyset['home'] or
+              keystroke.code in self.keyset['home']):
             rstr += self.move_home()
-        elif keystroke in self.keyset['end']:
+        elif (keystroke in self.keyset['end'] or
+              keystroke.code in self.keyset['end']):
             rstr += self.move_end()
-        elif keystroke in self.keyset['pgup']:
+        elif (keystroke in self.keyset['pgup'] or
+              keystroke.code in self.keyset['pgup']):
             rstr += self.move_pgup()
-        elif keystroke in self.keyset['pgdown']:
+        elif (keystroke in self.keyset['pgdown'] or
+              keystroke.code in self.keyset['pgdown']):
             rstr += self.move_pgdown()
-        elif keystroke in self.keyset['exit']:
+        elif (keystroke in self.keyset['exit'] or
+              keystroke.code in self.keyset['exit']):
             self._quit = True
         return rstr
 

--- a/x84/bbs/selector.py
+++ b/x84/bbs/selector.py
@@ -94,13 +94,14 @@ class Selector(AnsiWindow):
 
     def read(self):
         """ Reads input until the ENTER or ESCAPE key is pressed (Blocking). """
-        from x84.bbs import getch
+        from x84.bbs import getterminal
         from x84.bbs.output import echo
         self._selected = False
         self._quit = False
         echo(self.refresh())
+        term = getterminal()
         while not (self.selected or self.quit):
-            echo(self.process_keystroke(getch()) or u'')
+            echo(self.process_keystroke(term.inkey()) or u'')
         if self.quit:
             return None
         return self.selection

--- a/x84/bbs/selector.py
+++ b/x84/bbs/selector.py
@@ -77,18 +77,23 @@ class Selector(AnsiWindow):
         :returns: string sequence suitable for refresh.
         """
         self._moved = False
-        keystroke = hasattr(keystroke, 'code') and keystroke.code or keystroke
-        if keystroke in self.keyset['refresh']:
+        if (keystroke in self.keyset['refresh'] or
+                keystroke.code in self.keyset['refresh']):
             return self.refresh()
-        elif keystroke in self.keyset['left']:
+        elif (keystroke in self.keyset['left'] or
+              keystroke.code in self.keyset['left']):
             return self.move_left()
-        elif keystroke in self.keyset['right']:
+        elif (keystroke in self.keyset['right'] or
+              keystroke.code in self.keyset['right']):
             return self.move_right()
-        elif keystroke in self.keyset['toggle']:
+        elif (keystroke in self.keyset['toggle'] or
+              keystroke.code in self.keyset['toggle']):
             return self.toggle()
-        elif keystroke in self.keyset['exit']:
+        elif (keystroke in self.keyset['exit'] or
+              keystroke.code in self.keyset['exit']):
             self._quit = True
-        elif keystroke in self.keyset['enter']:
+        elif (keystroke in self.keyset['enter'] or
+              keystroke.code in self.keyset['enter']):
             self._selected = True
         return u''
 

--- a/x84/bbs/session.py
+++ b/x84/bbs/session.py
@@ -52,8 +52,12 @@ def getch(timeout=None):
     were built upon getch(), and as such, this remains ...
     """
     # mark deprecate in v2.1; remove entirely in v3.0
-    # warnings.warn('getch() is deprecated, use getterminal().inkey()')
+    warnings.warn('getch() is deprecated, use getterminal().inkey()')
     keystroke = getterminal().inkey(timeout)
+    # and this is the purpose for deprecation; old versions used to
+    # return None to indicate timeout; but it is more correct to always
+    # return strings, so that .lower() and such operations are always
+    # successful without conditional 'is None' checks.
     if keystroke == u'':
         return None
     if keystroke.is_sequence:

--- a/x84/default/editor.py
+++ b/x84/default/editor.py
@@ -390,9 +390,7 @@ def main(save_key=None, continue_draft=False):
         inp = term.inkey(1)
 
         # buffer keystrokes for repeat
-        if (not edit and inp is not None
-                and not isinstance(inp, int)
-                and inp.isdigit()):
+        if (not edit and inp and inp.isdigit()):
             digbuf += inp
             if len(digbuf) > 10:
                 # overflow,
@@ -410,8 +408,13 @@ def main(save_key=None, continue_draft=False):
             digbuf = u''
 
         # toggle edit mode,
-        if inp in keyset['command'] or not edit and inp in keyset['edit']:
+        if (inp in keyset['command'] or
+            inp.code in keyset['command']) or not edit and (
+                inp in keyset['edit'] or
+                inp.code in keyset['edit']):
+
             edit = not edit  # toggle
+
             if not edit:
                 # switched to command mode, merge our lines
 
@@ -419,6 +422,7 @@ def main(save_key=None, continue_draft=False):
 
                 merge()
                 lightbar.colors['highlight'] = term.yellow_reverse
+
             else:
                 # switched to edit mode, save draft,
                 # instantiate new line editor
@@ -441,7 +445,8 @@ def main(save_key=None, continue_draft=False):
             save_draft(save_key, get_lbcontent(lightbar))
 
         # command mode, insert line
-        elif not edit and inp in keyset['insert']:
+        elif not edit and (inp in keyset['insert'] or
+                           inp.code in keyset['insert']):
             for _ in count_repeat():
                 lightbar.content.insert(lightbar.index,
                                         (lightbar.index, HARDWRAP,))
@@ -450,7 +455,8 @@ def main(save_key=None, continue_draft=False):
             dirty = True
 
         # command mode; goto line
-        elif not edit and inp in keyset['goto']:
+        elif not edit and (inp in keyset['goto'] or
+                           inp.code in keyset['goto']):
             if num_repeat == -1:
                 # 'G' alone goes to end of file,
                 num_repeat = len(lightbar.content)
@@ -458,7 +464,8 @@ def main(save_key=None, continue_draft=False):
             echo(statusline(lightbar))
 
         # command mode; insert-before (switch to edit mode)
-        elif not edit and inp in keyset['insert-before']:
+        elif not edit and (inp in keyset['insert-before'] or
+                           inp.code in keyset['insert-before']):
             lightbar.content.insert(lightbar.index,
                                     (lightbar.index, HARDWRAP,))
             set_lbcontent(lightbar, get_lbcontent(lightbar))
@@ -470,7 +477,8 @@ def main(save_key=None, continue_draft=False):
             save_draft(save_key, get_lbcontent(lightbar))
 
         # command mode; insert-after (switch to edit mode)
-        elif not edit and inp in keyset['insert-after']:
+        elif not edit and (inp in keyset['insert-after'] or
+                           inp.code in keyset['insert-after']):
             lightbar.content.insert(lightbar.index + 1,
                                     (lightbar.index + 1, HARDWRAP,))
             set_lbcontent(lightbar, get_lbcontent(lightbar))
@@ -483,7 +491,8 @@ def main(save_key=None, continue_draft=False):
             save_draft(save_key, get_lbcontent(lightbar))
 
         # command mode, undo
-        elif not edit and inp in keyset['undo']:
+        elif not edit and (inp in keyset['undo'] or
+                           inp.code in keyset['insert-after']):
             for _ in count_repeat():
                 if len(UNDO):
                     set_lbcontent(lightbar, UNDO.pop())
@@ -493,15 +502,16 @@ def main(save_key=None, continue_draft=False):
                     break
 
         # command mode, join line
-        elif not edit and inp in keyset['join']:
+        elif not edit and (inp in keyset['join'] or
+                           inp.code in keyset['join']):
             for _ in count_repeat():
                 if lightbar.index + 1 < len(lightbar.content):
                     idx = lightbar.index
-                    lightbar.content[idx] = (idx,
-                                             WHITESPACE.join((
-                                                 lightbar.content[
-                                                     idx][1].rstrip(),
-                                                 lightbar.content[idx + 1][1].lstrip(),)))
+                    lightbar.content[idx] = (
+                        idx, WHITESPACE.join((
+                            lightbar.content[idx][1].rstrip(),
+                            lightbar.content[idx + 1][1].lstrip(),))
+                    )
                     del lightbar.content[idx + 1]
                     prior_length = len(lightbar.content)
                     set_lbcontent(lightbar, get_lbcontent(lightbar))
@@ -577,7 +587,8 @@ def main(save_key=None, continue_draft=False):
 
         # edit mode -- append character / backspace
         elif edit and inp is not None:
-            if (inp in keyset['rubout']
+            if ((inp in keyset['rubout'] or
+                 inp.code in keyset['rubout'])
                     and len(lneditor.content) == 0
                     and lightbar.index > 0):
                 # erase past margin,

--- a/x84/default/editor.py
+++ b/x84/default/editor.py
@@ -574,7 +574,8 @@ def main(save_key=None, continue_draft=False):
             if inp in (u'\r', term.KEY_ENTER,):
                 lightbar.content.insert(lightbar.index + 1,
                                         [lightbar.selection[0] + 1, u''])
-                inp = term.KEY_DOWN
+                # inject a down ...
+                inp.code = term.KEY_DOWN
                 dirty = True
             ucs = lightbar.process_keystroke(inp)
             if lightbar.moved:

--- a/x84/default/editor.py
+++ b/x84/default/editor.py
@@ -3,7 +3,7 @@
 import os
 
 # local
-from x84.bbs import getsession, getterminal, encode_pipe, echo, getch
+from x84.bbs import getsession, getterminal, encode_pipe, echo
 from x84.bbs import Lightbar, Selector, ScrollingEditor, showart
 from x84.bbs import syncterm_setfont
 
@@ -151,8 +151,9 @@ def yes_no(lightbar, msg, prompt_msg='are you sure? ', attr=None):
     sel.keyset['left'].extend(keyset['yes'])
     sel.keyset['right'].extend(keyset['no'])
     echo(sel.refresh())
+    term = getterminal()
     while True:
-        inp = getch()
+        inp = term.inkey()
         echo(sel.process_keystroke(inp))
         if((sel.selected and sel.selection == sel.left)
                 or inp in keyset['yes']):
@@ -386,7 +387,7 @@ def main(save_key=None, continue_draft=False):
             echo(redraw(lightbar, lneditor))
             dirty = False
         # poll for input
-        inp = getch(1)
+        inp = term.inkey(1)
 
         # buffer keystrokes for repeat
         if (not edit and inp is not None

--- a/x84/default/fbrowse.py
+++ b/x84/default/fbrowse.py
@@ -415,7 +415,8 @@ def browse_dir(session, db_desc, term, lightbar, directory, sub=False):
         isdir = bool(filepath[-1:] == os.path.sep)
         _, ext = os.path.splitext(filename.lower())
 
-        if inp in lightbar.keyset['home']:
+        if (inp in lightbar.keyset['home'] or
+                inp.code in lightbar.keyset['home']):
             # lightbar 'home' keystroke bug; redraw current line
             echo(lightbar.refresh_row(idx))
             echo(lightbar.refresh_row(lightbar.vitem_idx))
@@ -465,14 +466,14 @@ def browse_dir(session, db_desc, term, lightbar, directory, sub=False):
         clear_diz(term)
         save_diz = True
 
-        if lightbar.selected or inp in (term.KEY_LEFT, term.KEY_RIGHT,):
+        if lightbar.selected or inp.code in (term.KEY_LEFT, term.KEY_RIGHT,):
 
-            if sub and inp is term.KEY_LEFT:
+            if sub and inp.code == term.KEY_LEFT:
                 # term.KEY_LEFT backs up
                 return True
 
             if (isdir or is_flagged_dir(filename) and (
-                    lightbar.selected or inp is term.KEY_RIGHT)):
+                    lightbar.selected or inp.code == term.KEY_RIGHT)):
                 # 'select' key pressed
 
                 if filename == '..{0}'.format(os.path.sep):
@@ -546,7 +547,7 @@ def browse_dir(session, db_desc, term, lightbar, directory, sub=False):
         describe_file(term=term, diz=diz, directory=directory,
                       filename=filename, isdir=isdir)
         echo(lightbar.refresh_quick() + lightbar.fixate())
-        inp = None
+        inp = u''
 
 
 def main():

--- a/x84/default/fbrowse.py
+++ b/x84/default/fbrowse.py
@@ -5,7 +5,7 @@ import zipfile
 import os
 
 # local
-from x84.bbs import getsession, getterminal, echo, getch, syncterm_setfont
+from x84.bbs import getsession, getterminal, echo, syncterm_setfont
 from x84.bbs import get_ini, DBProxy, Lightbar, LineEditor
 from x84.bbs import send_modem, recv_modem
 from x84.default.common import filesize
@@ -396,7 +396,7 @@ def browse_dir(session, db_desc, term, lightbar, directory, sub=False):
     while True:
         # read from lightbar
         while not inp:
-            inp = getch(0.2)
+            inp = term.inkey(0.2)
             # respond to screen dimension change by redrawing
             if session.poll_event('refresh'):
                 draw_interface(term, lightbar)

--- a/x84/default/logoff.py
+++ b/x84/default/logoff.py
@@ -8,7 +8,7 @@ def main():
     #         Too many branches
     from x84.bbs import DBProxy, getsession, getterminal, echo
     from x84.bbs import ini, LineEditor, timeago, showart
-    from x84.bbs import disconnect, getch
+    from x84.bbs import disconnect
     import time
     import os
     session, term = getsession(), getterminal()
@@ -105,13 +105,13 @@ def main():
             refresh_automsg(-1)
             echo(u'\a')  # bel
             refresh_prompt(prompt_msg)
-        inp = getch(1)
+        inp = term.inkey(1)
         if inp in (u'g', u'G', term.KEY_EXIT, unichr(27), unichr(3),):
             # http://www.xfree86.org/4.5.0/ctlseqs.html
             # Restore xterm icon and window title from stack.
             echo(unichr(27) + u'[23;0t')
             echo(goodbye_msg)
-            getch(1.5)
+            term.inkey(1.5)
             disconnect('logoff.')
         elif inp in (u'n', u'N', term.KEY_DOWN, term.KEY_NPAGE,):
             idx = refresh_automsg(idx + 1)
@@ -133,6 +133,6 @@ def main():
                 session.send_event('global', ('automsg', True,))
                 refresh_automsg(idx)
                 echo(u''.join((u'\r\n\r\n', commit_msg,)))
-                getch(0.5)  # for effect, LoL
+                term.inkey(0.5)  # for effect, LoL
             # display prompt
             refresh_prompt(prompt_msg)

--- a/x84/default/online.py
+++ b/x84/default/online.py
@@ -200,7 +200,7 @@ def main():
     #         Too many branches
     #         Too many local variables
     #         Too many statements
-    from x84.bbs import getsession, getterminal, getch, echo
+    from x84.bbs import getsession, getterminal, echo
     session, term = getsession(), getterminal()
     SELF_ID = session.sid
     ayt_lastfresh = 0
@@ -218,7 +218,7 @@ def main():
 
     while True:
         ayt_lastfresh = broadcast_ayt(ayt_lastfresh)
-        inp = getch(POLL_KEY)
+        inp = term.inkey(POLL_KEY)
         if session.poll_event('refresh') or (
                 inp in (u' ', term.KEY_REFRESH, unichr(12))):
             dirty = time.time()

--- a/x84/default/online.py
+++ b/x84/default/online.py
@@ -219,27 +219,26 @@ def main():
     while True:
         ayt_lastfresh = broadcast_ayt(ayt_lastfresh)
         inp = term.inkey(POLL_KEY)
-        if session.poll_event('refresh') or (
-                inp in (u' ', term.KEY_REFRESH, unichr(12))):
+        if session.poll_event('refresh') or (inp in (u' ', unichr(12))):
             dirty = time.time()
             cur_row = 0
-        elif inp in (u'q', 'Q', term.KEY_EXIT, unichr(27)):
+        elif inp.lower() in (u'q', unichr(27)) or inp.code == term.KEY_EXIT:
             echo(u'\r\n\r\n')
             return
-        elif inp in (u'c', 'C'):
+        elif inp.lower() == u'c':
             cur_row = 0 if chat(sessions) else cur_row
             dirty = time.time()
-        elif inp in (u's', 'S'):
+        elif inp.lower() == u's':
             cur_row = 0 if sendmsg(sessions) else cur_row
             dirty = time.time()
-        elif inp is not None and 'sysop' in session.user.groups:
-            if inp in (u'e', u'E'):
+        elif inp and 'sysop' in session.user.groups:
+            if inp.lower() == u'e':
                 cur_row = 0 if edit(sessions) else cur_row
                 dirty = time.time()
-            elif inp in (u'v', u'V'):
+            elif inp.lower() == u'v':
                 cur_row = 0 if view(sessions) else cur_row + 3
                 dirty = time.time()
-            elif inp in (u'd', u'D'):
+            elif inp.lower() == u'd':
                 disconnect(sessions)
                 dirty = time.time()
 

--- a/x84/default/si.py
+++ b/x84/default/si.py
@@ -181,7 +181,9 @@ def main():
             echo(term.move(int(yloc), int(xloc)) + melt_colors[-1] + star)
 
     with term.hidden_cursor():
+
         while txt_x is not None and txt_y is not None:
+
             if session.poll_event('refresh'):
                 num_stars = int(num_stars)
                 stars = dict([(n, (random.choice('\\|/-'),
@@ -196,43 +198,44 @@ def main():
                                  + u' ' + line)
                 txt_x, txt_y = refresh()
                 continue
+
             inp = term.inkey(tm_out)
-            if inp in (term.KEY_UP, 'k'):
+
+            if inp.code == term.KEY_UP or inp.lower() == u'k':
                 if tm_out >= tm_min:
                     tm_out -= tm_step
-            elif inp in (term.KEY_DOWN, 'j'):
+            elif inp.code == term.KEY_DOWN or inp.lower() == u'j':
                 if tm_out <= tm_max:
                     tm_out += tm_step
-            elif inp in (term.KEY_LEFT, 'h'):
+            elif inp.code == term.KEY_LEFT or inp.lower() == u'h':
                 if num_stars > 2:
                     num_stars = int(num_stars * .5)
                     stars = dict([(n, (random.choice('\\|/-'),
                                        float(random.choice(range(term.width))),
                                        float(random.choice(range(term.height)))
                                        )) for n in range(num_stars)])
-            elif inp in (term.KEY_RIGHT, 'l'):
+            elif inp.code == term.KEY_RIGHT or inp.lower() == u'l':
                 if num_stars < (term.width * term.height) / 4:
                     num_stars = int(num_stars * 1.5)
                     stars = dict([(n, (random.choice('\\|/-'),
                                        float(random.choice(range(term.width))),
                                        float(random.choice(range(term.height)))
                                        )) for n in range(num_stars)])
-            elif inp in (u'*',) and not show_star:
-                show_star = True
-            elif inp in (u'*',) and show_star:
-                for star in stars:
-                    erase(star)
-                show_star = False
-            elif inp is not None:
+            elif inp in (u'*',):
+                show_star = not show_star
+                if not show_star:
+                    for star in stars:
+                        erase(star)
+            elif inp:
+                # any other key just exits, like a screen saver.
                 echo(term.move(term.height, 0))
                 break
+
             melt()
+
             for star_key, star_val in stars.items():
                 erase(star_key)
-                # pylint: disable=W0142
-                #         Used * or ** magic
                 stars[star_key] = iter_star(*star_val)
                 draw_star(*stars[star_key])
-            # pylint: disable=W0142
-            #         Used * or ** magic
+
             wind = iter_wind(*wind)

--- a/x84/default/si.py
+++ b/x84/default/si.py
@@ -7,7 +7,7 @@ def main():
     #         Too many local variables
     #         Used builtin function 'map'
     #         Too many branches
-    from x84.bbs import getsession, getterminal, echo, getch, syncterm_setfont
+    from x84.bbs import getsession, getterminal, echo, syncterm_setfont
     from x84.engine import __url__ as url
     import platform
     import random
@@ -83,7 +83,7 @@ def main():
                     term.width, width,),
                 u'\r\n\r\n',
                 u'press any key...',)))
-            getch()
+            term.inkey()
             return (None, None)
         if term.height < height:
             echo(u''.join((
@@ -93,7 +93,7 @@ def main():
                     term.height, height),
                 u'\r\n\r\n',
                 u'press any key...',)))
-            getch()
+            term.inkey()
             return (None, None)
         xloc = (term.width / 2) - (width / 2)
         yloc = (term.height / 2) - (height / 2)
@@ -196,7 +196,7 @@ def main():
                                  + u' ' + line)
                 txt_x, txt_y = refresh()
                 continue
-            inp = getch(tm_out)
+            inp = term.inkey(tm_out)
             if inp in (term.KEY_UP, 'k'):
                 if tm_out >= tm_min:
                     tm_out -= tm_step

--- a/x84/default/telnet.py
+++ b/x84/default/telnet.py
@@ -15,7 +15,7 @@ def main(host, port=None, encoding='cp437'):
     #         Too many statements
     import telnetlib
     from functools import partial
-    from x84.bbs import getsession, getterminal, echo, getch, from_cp437, telnet
+    from x84.bbs import getsession, getterminal, echo, from_cp437, telnet
     import logging
     log = logging.getLogger()
 
@@ -28,7 +28,7 @@ def main(host, port=None, encoding='cp437'):
         telnet.callback_cmdopt, env_term=session.env['TERM'], height=term.height, width=term.width))
     echo(u"\r\n\r\nEscape character is 'ctrl-^.'")
     if not session.user.get('expert', False):
-        getch(3)
+        term.inkey(3)
     echo(u'\r\nTrying %s:%s... ' % (host, port,))
     # pylint: disable=W0703
     #         Catching too general exception Exception
@@ -37,7 +37,7 @@ def main(host, port=None, encoding='cp437'):
     except Exception as err:
         echo(term.bold_red('\r\n%s\r\n' % (err,)))
         echo(u'\r\n press any key ..')
-        getch()
+        term.inkey()
         return
 
     echo(u'\r\n... ')
@@ -77,5 +77,5 @@ def main(host, port=None, encoding='cp437'):
     echo(u''.join(('\r\n\r\n', term.clear_el, term.normal, 'press any key')))
     echo(u'\x1b[r')  # unset 'set scrolling region', sometimes set by BBS's
     session.flush_event('input')
-    getch()
+    term.inkey()
     return


### PR DESCRIPTION
This PR is broken -- the old getch() returned "None", and many supporting functions check ``is None`` and need to be changed to check ``!= ""`` or simple truthy/falsey for length:
```
- inp = getch()
+ inp = term.inkey()
- if inp is not None:
+ if inp:
```