### PR TITLE
Prevent session continue after UnpicklingError

### DIFF
--- a/x84/bbs/session.py
+++ b/x84/bbs/session.py
@@ -5,6 +5,7 @@
 import collections
 import traceback
 import logging
+import pickle
 import time
 import imp
 import sys
@@ -628,7 +629,11 @@ class Session(object):
             # ask engine process for new event data,
             poll = min(0.5, waitfor) or 0.01
             if self.reader.poll(poll):
-                event, data = self.reader.recv()
+                try:
+                    event, data = self.reader.recv()
+                except pickle.UnpicklingError as err:
+                    self.log.error(err)
+                    disconnect(reason='{0}'.format(err))
                 # it is necessary to always buffer an event, as some
                 # side-effects may occur by doing so.  When buffer_event
                 # returns True, those side-effects caused no data to be


### PR DESCRIPTION
We like to accommodate the resumption of a session under many conditions, but
this one in particular is rather troubling. It seems when the operating system
is starved of memory (perhaps our fault -- because IPC buffer data has not been
freed?), the IPC data is first to trim-out; what we do is simply call for a
disconnect, using the UnPicklingError as the reason.

```
session.py:386   File "x84/bbs/session.py", line 631, in read_events
session.py:386     event, data = self.reader.recv()
session.py:386 UnpicklingError: invalid load key, '^R'.
session.py:339 resume main after general exception in logoff

session.py:386 File "x84/bbs/session.py", line 631, in read_events
session.py:386     event, data = self.reader.recv()
session.py:386 anonymous[telnet-193.136.124.211:13390] MemoryError
session.py:339 stop after general exception in main

terminal.py:279 goodbye: client exit
```