### PR TITLE
Support a larger max username length out-of-the-box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ run
 *~
 .tox
 MANIFEST
+python_modules
+.vscode

--- a/x84/default/nua.py
+++ b/x84/default/nua.py
@@ -47,7 +47,7 @@ new_usernames = get_ini(
 #: maximum length of user handles
 username_max_length = get_ini(
     section='nua', key='max_user', getter='getint'
-) or 10
+) or 12
 
 #: minimum length of user handles
 username_min_length = get_ini(
@@ -63,7 +63,7 @@ invalid_usernames = get_ini(
 #: login name validation as a regular expression
 username_re_validator = get_ini(
     section='nua', key='handle_validation'
-) or ['^[A-Za-z0-9]{3,11}$']
+) or ['^[A-Za-z0-9]{3,12}$']
 
 
 #: maximum length of user 'location' field


### PR DESCRIPTION
Hi, 

I love x84, however every time I installed I'd have to update default.ini, and its regex username handler to handle an addition 2 characters. The problem being, that "ispyhumanfly" was greater than 11 characters.

Though, it's super easy to configure these things in x84, I felt that as a first time installer, I shouldn't have to figure this kinda stuff out just yet. So I simplified it using the pre-existing framework. 

Regards,

ispy_