### PR TITLE
docs: Fix a few typos

### DIFF
--- a/x84/bbs/door.py
+++ b/x84/bbs/door.py
@@ -630,7 +630,7 @@ class DOSDoor(Door):
         return data
 
     def input_filter(self, data):
-        """ filter keyboard input (used for "throway" bug workaround). """
+        """ filter keyboard input (used for "throwaway" bug workaround). """
         return data if time.time() - self._stime > self.START_BLOCK else u''
 
     def resize(self):

--- a/x84/bbs/ini.py
+++ b/x84/bbs/ini.py
@@ -39,7 +39,7 @@ def init(lookup_bbs, lookup_log):
 
     # exploit last argument, presumed to be within a folder
     # writable by our process, and where the ini is wanted
-    # -- engine.py specifys a default of: ~/.x84/somefile.ini
+    # -- engine.py specifies a default of: ~/.x84/somefile.ini
     loaded = False
     cfg_logfile = lookup_log[-1]
     for cfg_logfile in lookup_log:

--- a/x84/bbs/lightbar.py
+++ b/x84/bbs/lightbar.py
@@ -355,7 +355,7 @@ class Lightbar(AnsiWindow):
             self.vitem_idx = self.visible_height - 2
 
         # if we are a shifted window, shift 1 line up while keeping our
-        # lightbar position until the bottom-most item is within visable range.
+        # lightbar position until the bottom-most item is within visible range.
         while (self.vitem_shift and self.vitem_shift + self.visible_height - 1
                 > len(self.content)):
             self.vitem_shift -= 1

--- a/x84/default/nua.py
+++ b/x84/default/nua.py
@@ -2,7 +2,7 @@
 """
 New user account script for x/84.
 
-This script is closely coupled with, and dependend on by profile.py.
+This script is closely coupled with, and dependent on by profile.py.
 """
 # std imports
 from __future__ import division

--- a/x84/default/top.py
+++ b/x84/default/top.py
@@ -213,7 +213,7 @@ def do_intro_art(term, session):
     """
     Display random art file, prompt for quick login.
 
-    Bonus: allow chosing other artfiles with '<' and '>'.
+    Bonus: allow choosing other artfiles with '<' and '>'.
     """
     # set syncterm font, if any
     if syncterm_font and term.kind.startswith('ansi'):

--- a/x84/default/weather.py
+++ b/x84/default/weather.py
@@ -308,7 +308,7 @@ def get_zipsearch(zipcode=u''):
 
 def chose_location_lightbar(locations):
     """
-    Lightbar pager for chosing a location.
+    Lightbar pager for choosing a location.
     """
     from x84.bbs import getterminal, echo, Lightbar
     term = getterminal()

--- a/x84/telnet.py
+++ b/x84/telnet.py
@@ -316,7 +316,7 @@ class TelnetClient(BaseClient):
 
     def _iac_sniffer(self, byte):
         """
-        Watches incomming data for Telnet IAC sequences.
+        Watches incoming data for Telnet IAC sequences.
         Passes the data, if any, with the IAC commands stripped to
         _recv_byte().
         """
@@ -400,7 +400,7 @@ class TelnetClient(BaseClient):
 
     def _three_byte_cmd(self, option):
         """
-        Handle incoming Telnet commmands that are three bytes long.
+        Handle incoming Telnet commands that are three bytes long.
         """
         cmd = self.telnet_got_cmd
         self.log.debug('recv IAC %s %s', name_option(cmd), name_option(option))

--- a/x84/terminal.py
+++ b/x84/terminal.py
@@ -304,7 +304,7 @@ def start_process(sid, env, CFG, child_pipes, kind, addrport,
     :param tuple addrport: ``(client-ip, client-port)`` as string and integer.
     :param tuple matrix_args: optional positional arguments to pass to matrix
                               script.
-    :param dict matrix_kwargs: optional keyward arguments to pass to matrix
+    :param dict matrix_kwargs: optional keyword arguments to pass to matrix
                                script.
     """
     # pylint: disable=R0913,R0914


### PR DESCRIPTION
There are small typos in:
- x84/bbs/door.py
- x84/bbs/ini.py
- x84/bbs/lightbar.py
- x84/default/nua.py
- x84/default/top.py
- x84/default/weather.py
- x84/telnet.py
- x84/terminal.py

Fixes:
- Should read `choosing` rather than `chosing`.
- Should read `visible` rather than `visable`.
- Should read `throwaway` rather than `throway`.
- Should read `specifies` rather than `specifys`.
- Should read `keyword` rather than `keyward`.
- Should read `incoming` rather than `incomming`.
- Should read `dependent` rather than `dependend`.
- Should read `commands` rather than `commmands`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md